### PR TITLE
Fix for: (use -source 5 or higher to enable generics)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,5 +17,22 @@
             <url>http://www.opensource.org/licenses/mit-license.php</url>
         </license>
     </licenses>
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.1</version>
+                    <configuration>
+                        <source>1.7</source>
+                        <target>1.7</target>
+                        <encoding>UTF-8</encoding>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
 
 </project>


### PR DESCRIPTION
I tried to build the project with command line: mvn install
The build has  failed with:  [ERROR] (use -source 5 or higher to enable generics)
[ERROR] /opt/java/OfflineReverseGeocode/src/main/java/geocode/GeoName.java:[30,7] error: static import declarations are not supported in -source 1.3
[ERROR] 
[ERROR] (use -source 5 or higher to enable static import declarations)
[ERROR] /opt/java/OfflineReverseGeocode/src/main/java/geocode/GeoName.java:[41,45] error: generics are not supported in -source 1.3
[ERROR] 
[ERROR] (use -source 5 or higher to enable generics)
[ERROR] /opt/java/OfflineReverseGeocode/src/main/java/geocode/GeoName.java:[72,5] error: annotations are not supported in -source 1.3

This is the fix
